### PR TITLE
Pipe 'yes' to the ExtPack installer

### DIFF
--- a/virtualbox/Dockerfile
+++ b/virtualbox/Dockerfile
@@ -6,7 +6,7 @@ RUN yum -y install $(yum -y list | grep VirtualBox | sort | tail -1 | cut -f 1 -
 
 RUN VERSION=$(VBoxManage --version | tail -1 | cut -f 1 -d "r") && \
     curl -Lo /Oracle_VM_VirtualBox_Extension_Pack-${VERSION}.vbox-extpack http://download.virtualbox.org/virtualbox/${VERSION}/Oracle_VM_VirtualBox_Extension_Pack-${VERSION}.vbox-extpack && \
-    VBoxManage extpack install Oracle_VM_VirtualBox_Extension_Pack-${VERSION}.vbox-extpack && \
+    yes | VBoxManage extpack install Oracle_VM_VirtualBox_Extension_Pack-${VERSION}.vbox-extpack && \
     rm -rf Oracle_VM_VirtualBox_Extension_Pack-${VERSION}.vbox-extpack
 
 RUN yum -y install make epel-release initscripts && yum -y install dkms


### PR DESCRIPTION
Recent versions of the ExtPack installer require a 'y/n' answer.

This simply uses the `yes` command to send it a `y`.